### PR TITLE
Isolate the `word_basket` output to a specific part of the file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     tags:
-        - "v*.*.*"
+      - "v*.*.*"
 
 jobs:
   build:
@@ -11,16 +11,16 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Check out repo
-      uses: actions/checkout@v2
-    - name: Set up Deno
-      uses: denoland/setup-deno@v1
-      with:
-        deno-version: v1.x
-    - name: Compile to executable
-      run: |-
-        deno task compile
-    - name: Create release in GitHub
-      uses: softprops/action-gh-release@v1
-      with:
-        files: bin/word_basket
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Compile to executable
+        run: |-
+          deno task compile
+      - name: Create release in GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: bin/word_basket

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- word_basket start -->
 | patience | creativity | clarity |
 | :------: | :--------: | :-----: |
 
@@ -5,3 +6,4 @@
   <summary>✨</summary>
   These words are chosen at random each day. New words will appear here tomorrow morning.
 </details>
+<!-- word_basket end -->

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,9 @@
+{
+  "version": "3",
+  "remote": {
+    "https://deno.land/std@0.159.0/fmt/colors.ts": "ff7dc9c9f33a72bd48bc24b21bbc1b4545d8494a431f17894dbc5fe92a938fc4",
+    "https://deno.land/std@0.159.0/testing/_diff.ts": "a23e7fc2b4d8daa3e158fa06856bedf5334ce2a2831e8bf9e509717f455adb2c",
+    "https://deno.land/std@0.159.0/testing/_format.ts": "cd11136e1797791045e639e9f0f4640d5b4166148796cad37e6ef75f7d7f3832",
+    "https://deno.land/std@0.159.0/testing/asserts.ts": "9ff3259f6cdc2908af478f9340f4e470d23234324bd33e7f74c683a00ed4d211"
+  }
+}

--- a/word_basket/mod.ts
+++ b/word_basket/mod.ts
@@ -1,5 +1,6 @@
 import { draw } from "./draw.ts";
 import { toExpandable, toTable } from "./formatter.ts";
+import { replaceSection } from "./section.ts";
 import wordsOfAffirmation from "./words.json" assert { type: "json" };
 
 const uniqueWords = new Set(wordsOfAffirmation);
@@ -7,10 +8,14 @@ const words = draw(uniqueWords, 3);
 
 const wordDisplay = toTable(words);
 const moreInfo = toExpandable(
-  "✨",
-  "These words are chosen at random each day. New words will appear here tomorrow morning.",
+  "These words are chosen at random each day. ✨",
+  "Take a look inside this repo to see how that works.",
 );
 const wordBasket = [wordDisplay, moreInfo].join("\n\n");
 
 const outputFile = Deno.env.get("WORD_BASKET_OUTPUT_FILE") ?? "MOCK_README.md";
-await Deno.writeTextFile(outputFile, wordBasket);
+
+const content = await Deno.readTextFile(outputFile);
+const updatedContent = replaceSection(content, "word_basket", wordBasket);
+
+await Deno.writeTextFile(outputFile, updatedContent);

--- a/word_basket/section.ts
+++ b/word_basket/section.ts
@@ -1,0 +1,45 @@
+export function replaceSection(
+  document: string,
+  section: string,
+  content: string,
+): string {
+  if (!hasSection(document, section)) {
+    throw new Error(`no section with tag "${section}" found in the document`);
+  }
+
+  const startComment = toMarkerComment(section, "start");
+  const endComment = toMarkerComment(section, "end");
+
+  const contentStartIndex = document.indexOf(startComment) +
+    startComment.length;
+  const contentEndIndex = document.indexOf(endComment) - 1;
+
+  return document.slice(0, contentStartIndex) + "\n" + content +
+    document.slice(contentEndIndex);
+}
+
+export function clearSection(document: string, section: string): string {
+  if (!hasSection(document, section)) {
+    throw new Error(`no section with tag "${section}" found in the document`);
+  }
+
+  const startComment = toMarkerComment(section, "start");
+  const endComment = toMarkerComment(section, "end");
+
+  const contentStartIndex = document.indexOf(startComment) +
+    startComment.length;
+  const contentEndIndex = document.indexOf(endComment) - 1;
+
+  return document.slice(0, contentStartIndex) + document.slice(contentEndIndex);
+}
+
+export function hasSection(document: string, section: string): boolean {
+  const startComment = toMarkerComment(section, "start");
+  const endComment = toMarkerComment(section, "end");
+
+  return document.includes(startComment) && document.includes(endComment);
+}
+
+function toMarkerComment(tag: string, marker: string): string {
+  return `<!-- ${tag} ${marker} -->`;
+}

--- a/word_basket/section_test.ts
+++ b/word_basket/section_test.ts
@@ -1,30 +1,44 @@
 import { assertEquals } from "https://deno.land/std@0.159.0/testing/asserts.ts";
 
-// Deno.test("clearSection empties a tagged section", () => {
-//   const before = `
-// Keep what's here.
+function clearSection(document: string, section: string) {
+  if (!hasSection(document, section)) {
+    throw new Error(`no section with tag "${section}" found in the document`)
+  }
 
-// <!-- section start -->
-// Remove this
-// <!-- section end -->
+  const startComment = toMarkerComment(section, "start")
+  const endComment = toMarkerComment(section, "end")
 
-// Leave this alone.
-//   `.trim();
+  const contentStartIndex = document.indexOf(startComment) + startComment.length
+  const contentEndIndex = document.indexOf(endComment) - 1
 
-//   const after  = `
-// Keep what's here.
+  return document.slice(0, contentStartIndex) + document.slice(contentEndIndex)
+}
 
-// <!-- section start -->
-// <!-- section end -->
+Deno.test("clearSection empties a tagged section", () => {
+  const before = `
+Keep what's here.
 
-// Leave this alone.
-//   `.trim();
+<!-- section start -->
+Remove this
+<!-- section end -->
+
+Leave this alone.
+  `.trim();
+
+  const after  = `
+Keep what's here.
+
+<!-- section start -->
+<!-- section end -->
+
+Leave this alone.
+  `.trim();
 
 
-//   const result = clearSection(before, "section");
+  const result = clearSection(before, "section");
 
-//   assertEquals(result, after);
-// });
+  assertEquals(result, after);
+});
 
 function toMarkerComment(tag: string, marker: string) {
   return `<!-- ${tag} ${marker} -->`;

--- a/word_basket/section_test.ts
+++ b/word_basket/section_test.ts
@@ -1,0 +1,63 @@
+import { assertEquals } from "https://deno.land/std@0.159.0/testing/asserts.ts";
+
+// Deno.test("clearSection empties a tagged section", () => {
+//   const before = `
+// Keep what's here.
+
+// <!-- section start -->
+// Remove this
+// <!-- section end -->
+
+// Leave this alone.
+//   `.trim();
+
+//   const after  = `
+// Keep what's here.
+
+// <!-- section start -->
+// <!-- section end -->
+
+// Leave this alone.
+//   `.trim();
+
+
+//   const result = clearSection(before, "section");
+
+//   assertEquals(result, after);
+// });
+
+function toMarkerComment(tag: string, marker: string) {
+  return `<!-- ${tag} ${marker} -->`;
+}
+
+function hasSection(document: string, section: string): boolean {
+  const startComment = toMarkerComment(section, "start");
+  const endComment = toMarkerComment(section, "end");
+
+  return document.includes(startComment) && document.includes(endComment)
+}
+
+Deno.test("hasSection is true if there's a matching start and end comment", () => {
+  const document = `
+<!-- section start -->
+Content of section
+<!-- section end -->
+  `.trim();
+
+  assertEquals(hasSection(document, "section"), true);
+});
+
+Deno.test("hasSection is false if a section comment is missing", () => {
+  const missingStart = `
+Content of section
+<!-- section end -->
+  `.trim();
+
+  const missingEnd = `
+<!-- section start -->
+Content of section
+  `.trim();
+
+  assertEquals(hasSection(missingStart, "section"), false);
+  assertEquals(hasSection(missingEnd, "section"), false);
+});

--- a/word_basket/section_test.ts
+++ b/word_basket/section_test.ts
@@ -1,17 +1,60 @@
 import { assertEquals } from "https://deno.land/std@0.159.0/testing/asserts.ts";
 
-function clearSection(document: string, section: string) {
+function replaceSection(document: string, section: string, content: string) {
   if (!hasSection(document, section)) {
-    throw new Error(`no section with tag "${section}" found in the document`)
+    throw new Error(`no section with tag "${section}" found in the document`);
   }
 
-  const startComment = toMarkerComment(section, "start")
-  const endComment = toMarkerComment(section, "end")
+  const startComment = toMarkerComment(section, "start");
+  const endComment = toMarkerComment(section, "end");
 
-  const contentStartIndex = document.indexOf(startComment) + startComment.length
-  const contentEndIndex = document.indexOf(endComment) - 1
+  const contentStartIndex = document.indexOf(startComment) +
+    startComment.length;
+  const contentEndIndex = document.indexOf(endComment) - 1;
 
-  return document.slice(0, contentStartIndex) + document.slice(contentEndIndex)
+  return document.slice(0, contentStartIndex) + "\n" + content +
+    document.slice(contentEndIndex);
+}
+
+Deno.test("replaceSection replaces content in a tagged section", () => {
+  const before = `
+Keep what's here.
+
+<!-- section start -->
+Remove this
+<!-- section end -->
+
+Leave this alone.
+  `.trim();
+
+  const after = `
+Keep what's here.
+
+<!-- section start -->
+Replace with this content
+<!-- section end -->
+
+Leave this alone.
+  `.trim();
+
+  const result = replaceSection(before, "section", "Replace with this content");
+
+  assertEquals(result, after);
+});
+
+function clearSection(document: string, section: string) {
+  if (!hasSection(document, section)) {
+    throw new Error(`no section with tag "${section}" found in the document`);
+  }
+
+  const startComment = toMarkerComment(section, "start");
+  const endComment = toMarkerComment(section, "end");
+
+  const contentStartIndex = document.indexOf(startComment) +
+    startComment.length;
+  const contentEndIndex = document.indexOf(endComment) - 1;
+
+  return document.slice(0, contentStartIndex) + document.slice(contentEndIndex);
 }
 
 Deno.test("clearSection empties a tagged section", () => {
@@ -25,7 +68,7 @@ Remove this
 Leave this alone.
   `.trim();
 
-  const after  = `
+  const after = `
 Keep what's here.
 
 <!-- section start -->
@@ -33,7 +76,6 @@ Keep what's here.
 
 Leave this alone.
   `.trim();
-
 
   const result = clearSection(before, "section");
 
@@ -48,7 +90,7 @@ function hasSection(document: string, section: string): boolean {
   const startComment = toMarkerComment(section, "start");
   const endComment = toMarkerComment(section, "end");
 
-  return document.includes(startComment) && document.includes(endComment)
+  return document.includes(startComment) && document.includes(endComment);
 }
 
 Deno.test("hasSection is true if there's a matching start and end comment", () => {

--- a/word_basket/section_test.ts
+++ b/word_basket/section_test.ts
@@ -1,20 +1,5 @@
 import { assertEquals } from "https://deno.land/std@0.159.0/testing/asserts.ts";
-
-function replaceSection(document: string, section: string, content: string) {
-  if (!hasSection(document, section)) {
-    throw new Error(`no section with tag "${section}" found in the document`);
-  }
-
-  const startComment = toMarkerComment(section, "start");
-  const endComment = toMarkerComment(section, "end");
-
-  const contentStartIndex = document.indexOf(startComment) +
-    startComment.length;
-  const contentEndIndex = document.indexOf(endComment) - 1;
-
-  return document.slice(0, contentStartIndex) + "\n" + content +
-    document.slice(contentEndIndex);
-}
+import { clearSection, hasSection, replaceSection } from "./section.ts";
 
 Deno.test("replaceSection replaces content in a tagged section", () => {
   const before = `
@@ -42,21 +27,6 @@ Leave this alone.
   assertEquals(result, after);
 });
 
-function clearSection(document: string, section: string) {
-  if (!hasSection(document, section)) {
-    throw new Error(`no section with tag "${section}" found in the document`);
-  }
-
-  const startComment = toMarkerComment(section, "start");
-  const endComment = toMarkerComment(section, "end");
-
-  const contentStartIndex = document.indexOf(startComment) +
-    startComment.length;
-  const contentEndIndex = document.indexOf(endComment) - 1;
-
-  return document.slice(0, contentStartIndex) + document.slice(contentEndIndex);
-}
-
 Deno.test("clearSection empties a tagged section", () => {
   const before = `
 Keep what's here.
@@ -81,17 +51,6 @@ Leave this alone.
 
   assertEquals(result, after);
 });
-
-function toMarkerComment(tag: string, marker: string) {
-  return `<!-- ${tag} ${marker} -->`;
-}
-
-function hasSection(document: string, section: string): boolean {
-  const startComment = toMarkerComment(section, "start");
-  const endComment = toMarkerComment(section, "end");
-
-  return document.includes(startComment) && document.includes(endComment);
-}
 
 Deno.test("hasSection is true if there's a matching start and end comment", () => {
   const document = `


### PR DESCRIPTION
I like the words of the day, but I want to be able to put other information in this README too if needed. So instead of replacing everything in the README, this change will replace whatever is within the tagged section.

```md
Safe to modify.

<!-- word_basket start -->
Still changed by the daily action.
<!-- word_basket end -->

Safe to modify.
```