### PR TITLE
Update deno permission flags

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --allow-env --allow-write word_basket/mod.ts",
-    "compile": "deno compile --output bin/word_basket --allow-env --allow-write word_basket/mod.ts"
+    "dev": "deno run --allow-env --allow-read=MOCK_README.md --allow-write=MOCK_README.md word_basket/mod.ts",
+    "compile": "deno compile --output bin/word_basket --allow-env --allow-read=README.md --allow-write=README.md word_basket/mod.ts"
   }
 }


### PR DESCRIPTION
Both `dev` and `compile` tasks require explicit read permissions (I probably should have noticed when Deno was prompting me for access on each run).

This should grant them limited access to the `MOCK_README.md` file during development and the `README.md` file in the compiled executable.